### PR TITLE
Fix : Missing update for speed data

### DIFF
--- a/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_quadrotor_model.cpp
+++ b/src/plugins/simulator/physics_engines/pointmass3d/pointmass3d_quadrotor_model.cpp
@@ -81,6 +81,7 @@ namespace argos {
 
    void CPointMass3DQuadRotorModel::UpdateFromEntityStatus() {
       m_sDesiredPositionData = m_cQuadRotorEntity.GetPositionControlData();
+      m_sDesiredSpeedData = m_cQuadRotorEntity.GetSpeedControlData();
    }
 
    /****************************************/


### PR DESCRIPTION
The quadrotor_speed_actuator was not working due to the physics engine never updating the speed data to move the robot.  

The missing `GetSpeedControlData()` was added.